### PR TITLE
Feature/add all argument

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -37,7 +37,7 @@ type Ast struct {
 	Environment    []string                           `json:"environment"`
 }
 
-func NewGenericTemplateBasedEncoder(templateDir string, service *descriptor.ServiceDescriptorProto, file *descriptor.FileDescriptorProto, debug bool, destinationDir string) (e *GenericTemplateBasedEncoder) {
+func NewGenericServiceTemplateBasedEncoder(templateDir string, service *descriptor.ServiceDescriptorProto, file *descriptor.FileDescriptorProto, debug bool, destinationDir string) (e *GenericTemplateBasedEncoder) {
 	e = &GenericTemplateBasedEncoder{
 		service:        service,
 		file:           file,
@@ -48,6 +48,22 @@ func NewGenericTemplateBasedEncoder(templateDir string, service *descriptor.Serv
 
 	if debug {
 		log.Printf("new encoder: file=%q service=%q template-dir=%q", file.GetName(), service.GetName(), templateDir)
+	}
+
+	return
+}
+
+func NewGenericTemplateBasedEncoder(templateDir string, file *descriptor.FileDescriptorProto, debug bool, destinationDir string) (e *GenericTemplateBasedEncoder) {
+	e = &GenericTemplateBasedEncoder{
+		service:        nil,
+		file:           file,
+		templateDir:    templateDir,
+		debug:          debug,
+		destinationDir: destinationDir,
+	}
+
+	if debug {
+		log.Printf("new encoder: file=%q template-dir=%q", file.GetName(), templateDir)
 	}
 
 	return

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/golang/protobuf/protoc-gen-go/generator"
 )
 


### PR DESCRIPTION
Add an *all* option argument that will parse every protofiles (not only those with services).
exemple:
```
protoc -I. --gotemplate_out=template_dir=templates,debug=true,all=true:output ./protos/*.proto
```