### PR TITLE
get package name only for descriptor message typed

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -115,7 +115,10 @@ func isFieldRepeated(f *descriptor.FieldDescriptorProto) bool {
 }
 
 func goTypeWithPackage(f *descriptor.FieldDescriptorProto) string {
-	pkg := getPackageTypeName(*f.TypeName)
+	pkg := ""
+	if *f.Type == descriptor.FieldDescriptorProto_TYPE_MESSAGE {
+		pkg = getPackageTypeName(*f.TypeName)
+	}
 	return goType(pkg, f)
 }
 


### PR DESCRIPTION
This PR fixes an issue on my previous PR #58 :
```GetPackageTypeName``` must only be called when the type of FieldDescriptorProto is FieldDescriptorProto_TYPE_MESSAGE otherwise it panics.