### PR TITLE
add helper getEnumValue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ install:
 
 .PHONY: test
 test:	install
+	cd examples/enum && make
 	cd examples/import && make
 	cd examples/dummy && make
 	cd examples/flow && make

--- a/encoder.go
+++ b/encoder.go
@@ -17,6 +17,7 @@ type GenericTemplateBasedEncoder struct {
 	templateDir    string
 	service        *descriptor.ServiceDescriptorProto
 	file           *descriptor.FileDescriptorProto
+	enum           []*descriptor.EnumDescriptorProto
 	debug          bool
 	destinationDir string
 }
@@ -34,6 +35,7 @@ type Ast struct {
 	Filename       string                             `json:"filename"`
 	TemplateDir    string                             `json:"template-dir"`
 	Service        *descriptor.ServiceDescriptorProto `json:"service"`
+	Enum           []*descriptor.EnumDescriptorProto  `json:"enum"`
 }
 
 func NewGenericServiceTemplateBasedEncoder(templateDir string, service *descriptor.ServiceDescriptorProto, file *descriptor.FileDescriptorProto, debug bool, destinationDir string) (e *GenericTemplateBasedEncoder) {
@@ -43,8 +45,8 @@ func NewGenericServiceTemplateBasedEncoder(templateDir string, service *descript
 		templateDir:    templateDir,
 		debug:          debug,
 		destinationDir: destinationDir,
+		enum:           file.GetEnumType(),
 	}
-
 	if debug {
 		log.Printf("new encoder: file=%q service=%q template-dir=%q", file.GetName(), service.GetName(), templateDir)
 	}
@@ -57,10 +59,10 @@ func NewGenericTemplateBasedEncoder(templateDir string, file *descriptor.FileDes
 		service:        nil,
 		file:           file,
 		templateDir:    templateDir,
+		enum:           file.GetEnumType(),
 		debug:          debug,
 		destinationDir: destinationDir,
 	}
-
 	if debug {
 		log.Printf("new encoder: file=%q template-dir=%q", file.GetName(), templateDir)
 	}
@@ -117,6 +119,7 @@ func (e *GenericTemplateBasedEncoder) genAst(templateFilename string) (*Ast, err
 		RawFilename:    templateFilename,
 		Filename:       "",
 		Service:        e.service,
+		Enum:           e.enum,
 	}
 	buffer := new(bytes.Buffer)
 	tmpl, err := template.New("").Funcs(ProtoHelpersFuncMap).Parse(templateFilename)

--- a/examples/enum/Makefile
+++ b/examples/enum/Makefile
@@ -1,0 +1,13 @@
+.PHONY: build
+build:
+	mkdir -p output
+	protoc -I. --gotemplate_out=template_dir=templates,debug=true,all=true:output proto/*.proto
+
+
+.PHONY: re
+re: clean build
+
+
+.PHONY: clean
+clean:
+	rm -rf output

--- a/examples/enum/output/enum.txt
+++ b/examples/enum/output/enum.txt
@@ -1,0 +1,9 @@
+-red
+-blue
+-black
+-yellow
+-green
+-dark
+-white
+-gray
+-orange

--- a/examples/enum/proto/sample.proto
+++ b/examples/enum/proto/sample.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+package Sample;
+
+enum Colors {
+    red = 0;
+    blue = 1;
+    black = 2;
+    yellow = 3;
+    green = 4;
+    dark = 5;
+    white = 6;
+    gray = 7;
+    orange = 8;
+}

--- a/examples/enum/templates/enum.txt.tmpl
+++ b/examples/enum/templates/enum.txt.tmpl
@@ -1,0 +1,2 @@
+{{range $m := "colors" | getEnumValue .Enum }}-{{$m.Name}}
+{{end}}

--- a/helpers.go
+++ b/helpers.go
@@ -65,6 +65,7 @@ var ProtoHelpersFuncMap = template.FuncMap{
 	},
 	"snakeCase":             xstrings.ToSnakeCase,
 	"getMessageType":        getMessageType,
+	"getEnumValue":          getEnumValue,
 	"isFieldMessage":        isFieldMessage,
 	"isFieldRepeated":       isFieldRepeated,
 	"goType":                goType,
@@ -92,6 +93,16 @@ func getMessageType(f *descriptor.FileDescriptorProto, name string) *descriptor.
 	for _, m := range f.MessageType {
 		if target == *m.Name {
 			return m
+		}
+	}
+
+	return nil
+}
+
+func getEnumValue(f []*descriptor.EnumDescriptorProto, name string) []*descriptor.EnumValueDescriptorProto {
+	for _, item := range f {
+		if strings.EqualFold(*item.Name, name) {
+			return item.GetValue()
 		}
 	}
 


### PR DESCRIPTION
This PR adds the method getEnumValue in our helpers. The goal is to have a quick and efficient way to loop through a chosen Enum described in a proto file. The filter is case-insensitive.

I provided a sample to illustrate what it does.

(PS) If you have a better name for this helper do not hesitate to propose.