### PR TITLE
Fix error on use pipeline after splitArray result

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -39,8 +39,8 @@ var ProtoHelpersFuncMap = template.FuncMap{
 		a, _ := json.MarshalIndent(v, "", "  ")
 		return string(a)
 	},
-	"splitArray": func(sep string, s string) []string {
-		var r []string
+	"splitArray": func(sep string, s string) []interface{} {
+		var r []interface{}
 		t := strings.Split(s, sep)
 		for i := range t {
 			if t[i] != "" {


### PR DESCRIPTION
Hi team,

I tried to use go-kit templates, but I got templating error like the below.

```
cd pb; protoc --gotemplate_out=destination_dir=../gen,template_dir=../templates/{{.File.Package}}/gen:../gen ./echo.proto
panic: template: grpc.go.tmpl:60:97: executing "grpc.go.tmpl" at <last>: wrong type for value; expected []interface {}; got []string

goroutine 1 [running]:
main.(*GenericTemplateBasedEncoder).Files(0xc42008b860, 0x22, 0xc420061080, 0xc420170000)
        /Users/shiwano/code/src/github.com/moul/protoc-gen-gotemplate/encoder.go:194 +0x520
main.main()
        /Users/shiwano/code/src/github.com/moul/protoc-gen-gotemplate/main.go:130 +0x402
--gotemplate_out: protoc-gen-gotemplate: Plugin failed with status code 2.
```

This error can be reproduced on http://protoc-gen-gotemplate.m.42.am/ with code the below.

```proto
syntax = "proto3";
package echo;
option go_package = "echopb";
service EchoService {
  rpc Echo(EchoMessage) returns (EchoMessage) {}
}
message EchoMessage {
  string message = 1;
}
```

```
{{- range .Service.Method}}
{{.InputType | splitArray "." | last}}
{{- end}}
```

It seems like that an error occurs by using pipeline after `[]string`. It resolved by that `splitArray` helper returns `[]interface{}` instead of `[]string`. Cound you review it?

Thanks.