### PR TITLE
add new helpers

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -52,6 +52,7 @@ func NewGenericServiceTemplateBasedEncoder(templateDir string, service *descript
 	if debug {
 		log.Printf("new encoder: file=%q service=%q template-dir=%q", file.GetName(), service.GetName(), templateDir)
 	}
+	pgghelpers.InitPathMap(file)
 
 	return
 }
@@ -68,6 +69,8 @@ func NewGenericTemplateBasedEncoder(templateDir string, file *descriptor.FileDes
 	if debug {
 		log.Printf("new encoder: file=%q template-dir=%q", file.GetName(), templateDir)
 	}
+	pgghelpers.InitPathMap(file)
+	pgghelpers.InitPathMap(file)
 
 	return
 }

--- a/encoder.go
+++ b/encoder.go
@@ -70,7 +70,6 @@ func NewGenericTemplateBasedEncoder(templateDir string, file *descriptor.FileDes
 		log.Printf("new encoder: file=%q template-dir=%q", file.GetName(), templateDir)
 	}
 	pgghelpers.InitPathMap(file)
-	pgghelpers.InitPathMap(file)
 
 	return
 }

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -136,6 +136,8 @@ func InitPathMaps(files []*descriptor.FileDescriptorProto) {
 	}
 }
 
+// addToPathMap traverses through the AST adding SourceCodeInfo_Location entries to the pathMap.
+// Since the AST is a tree, the recursion finishes once it has gone through all the nodes.
 func addToPathMap(info *descriptor.SourceCodeInfo, i interface{}, path []int32) {
 	loc := findLoc(info, path)
 	if loc != nil {

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -220,7 +220,7 @@ func leadingDetachedComments(i interface{}) []string {
 	return loc.GetLeadingDetachedComments()
 }
 
-func stringFieldExtension(fieldId int32, f *descriptor.FieldDescriptorProto) string {
+func stringFieldExtension(fieldID int32, f *descriptor.FieldDescriptorProto) string {
 	if f == nil {
 		return ""
 	}
@@ -231,18 +231,18 @@ func stringFieldExtension(fieldId int32, f *descriptor.FieldDescriptorProto) str
 	var extensionType *string
 
 	eds := proto.RegisteredExtensions(f.Options)
-	if eds[fieldId] == nil {
+	if eds[fieldID] == nil {
 		ed := &proto.ExtensionDesc{
 			ExtendedType:  extendedType,
 			ExtensionType: extensionType,
-			Field:         fieldId,
-			Tag:           fmt.Sprintf("bytes,%d", fieldId),
+			Field:         fieldID,
+			Tag:           fmt.Sprintf("bytes,%d", fieldID),
 		}
 		proto.RegisterExtension(ed)
 		eds = proto.RegisteredExtensions(f.Options)
 	}
 
-	ext, err := proto.GetExtension(f.Options, eds[fieldId])
+	ext, err := proto.GetExtension(f.Options, eds[fieldID])
 	if err != nil {
 		return ""
 	}
@@ -255,7 +255,7 @@ func stringFieldExtension(fieldId int32, f *descriptor.FieldDescriptorProto) str
 	return *str
 }
 
-func boolFieldExtension(fieldId int32, f *descriptor.FieldDescriptorProto) bool {
+func boolFieldExtension(fieldID int32, f *descriptor.FieldDescriptorProto) bool {
 	if f == nil {
 		return false
 	}
@@ -266,18 +266,18 @@ func boolFieldExtension(fieldId int32, f *descriptor.FieldDescriptorProto) bool 
 	var extensionType *bool
 
 	eds := proto.RegisteredExtensions(f.Options)
-	if eds[fieldId] == nil {
+	if eds[fieldID] == nil {
 		ed := &proto.ExtensionDesc{
 			ExtendedType:  extendedType,
 			ExtensionType: extensionType,
-			Field:         fieldId,
-			Tag:           fmt.Sprintf("varint,%d", fieldId),
+			Field:         fieldID,
+			Tag:           fmt.Sprintf("varint,%d", fieldID),
 		}
 		proto.RegisterExtension(ed)
 		eds = proto.RegisteredExtensions(f.Options)
 	}
 
-	ext, err := proto.GetExtension(f.Options, eds[fieldId])
+	ext, err := proto.GetExtension(f.Options, eds[fieldID])
 	if err != nil {
 		return false
 	}

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -593,8 +593,9 @@ func goType(pkg string, f *descriptor.FieldDescriptorProto) string {
 }
 
 func goZeroValue(f *descriptor.FieldDescriptorProto) string {
+	const nilString = "nil"
 	if *f.Label == descriptor.FieldDescriptorProto_LABEL_REPEATED {
-		return "nil"
+		return nilString
 	}
 	switch *f.Type {
 	case descriptor.FieldDescriptorProto_TYPE_DOUBLE:
@@ -614,13 +615,13 @@ func goZeroValue(f *descriptor.FieldDescriptorProto) string {
 	case descriptor.FieldDescriptorProto_TYPE_STRING:
 		return "\"\""
 	case descriptor.FieldDescriptorProto_TYPE_MESSAGE:
-		return "nil"
+		return nilString
 	case descriptor.FieldDescriptorProto_TYPE_BYTES:
 		return "0"
 	case descriptor.FieldDescriptorProto_TYPE_ENUM:
-		return "nil"
+		return nilString
 	default:
-		return "nil"
+		return nilString
 	}
 }
 


### PR DESCRIPTION
I have added quite a few helpers that I have used for documentation and client library generation.

goZeroValue:
returns the Go zero value for a field.

leadingComment,
trailingComment,
leadingDetachedComments:
returns the comments in the protobuf file near the item.

stringFieldExtension,
boolFieldExtension:
returns either a string or a bool field extension in the protobuf file when given the extension id.

isFieldMap,
fieldMapKeyType,
fieldMapValueType:
functions to figure out if a field is a map and what types are the keys and values.

replaceDict:
does a replace for every string in a sprig dictionary.