### PR TITLE
Add a flag to change which type to iterate over in order to create files

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,14 @@ You can specify custom options, as follow:
 $> protoc --gotemplate_out=debug=true,template_dir=/path/to/template/directory:. input.proto
 ```
 
-| Option                | Default Value | Accepted Values           | Description
-|-----------------------|---------------|---------------------------|-----------------------
-| `template_dir`        | `./template`  | absolute or relative path | path to look for templates
-| `destination_dir`     | `.`           | absolute or relative path | base path to write output
-| `single-package-mode` | *false*       | `true` or `false`         | if *true*, `protoc` won't accept multiple packages to be compiled at once (*!= from `all`*), but will support `Message` lookup across the imported protobuf dependencies
-| `debug`               | *false*       | `true` or `false`         | if *true*, `protoc` will generate a more verbose output
-| `all`                 | *false*       | `true` or `false`         | if *true*, protobuf files without `Service` will also be parsed
+| Option                | Default Value | Accepted Values                         | Description
+|-----------------------|---------------|-----------------------------------------|-----------------------
+| `template_dir`        | `./template`  | absolute or relative path               | path to look for templates
+| `destination_dir`     | `.`           | absolute or relative path               | base path to write output
+| `single-package-mode` | *false*       | `true` or `false`                       | if *true*, `protoc` won't accept multiple packages to be compiled at once (*!= from `all`*), but will support `Message` lookup across the imported protobuf dependencies
+| `debug`               | *false*       | `true` or `false`                       | if *true*, `protoc` will generate a more verbose output
+| `type`                | `service`     | `none`, `service`, `file`, or `message` | Which type of definition to iterate over and generate templates for.
+| `all`                 | *false*       | `true` or `false`                       | if *true*, protobuf files without `Service` will also be parsed. Identical to type=file
 
 ##### Hints
 

--- a/encoder.go
+++ b/encoder.go
@@ -18,7 +18,9 @@ import (
 type GenericTemplateBasedEncoder struct {
 	templateDir    string
 	service        *descriptor.ServiceDescriptorProto
+	message        *descriptor.DescriptorProto
 	file           *descriptor.FileDescriptorProto
+	files          []*descriptor.FileDescriptorProto
 	enum           []*descriptor.EnumDescriptorProto
 	debug          bool
 	destinationDir string
@@ -32,16 +34,19 @@ type Ast struct {
 	PWD            string                             `json:"pwd"`
 	Debug          bool                               `json:"debug"`
 	DestinationDir string                             `json:"destination-dir"`
+	Files          []*descriptor.FileDescriptorProto  `json:"file"`
 	File           *descriptor.FileDescriptorProto    `json:"file"`
 	RawFilename    string                             `json:"raw-filename"`
 	Filename       string                             `json:"filename"`
 	TemplateDir    string                             `json:"template-dir"`
 	Service        *descriptor.ServiceDescriptorProto `json:"service"`
+	Message        *descriptor.DescriptorProto        `json:"message"`
 	Enum           []*descriptor.EnumDescriptorProto  `json:"enum"`
 }
 
 func NewGenericServiceTemplateBasedEncoder(templateDir string, service *descriptor.ServiceDescriptorProto, file *descriptor.FileDescriptorProto, debug bool, destinationDir string) (e *GenericTemplateBasedEncoder) {
 	e = &GenericTemplateBasedEncoder{
+		message:        nil,
 		service:        service,
 		file:           file,
 		templateDir:    templateDir,
@@ -53,6 +58,40 @@ func NewGenericServiceTemplateBasedEncoder(templateDir string, service *descript
 		log.Printf("new encoder: file=%q service=%q template-dir=%q", file.GetName(), service.GetName(), templateDir)
 	}
 	pgghelpers.InitPathMap(file)
+
+	return
+}
+
+func NewGenericMessageTemplateBasedEncoder(templateDir string, message *descriptor.DescriptorProto, file *descriptor.FileDescriptorProto, debug bool, destinationDir string) (e *GenericTemplateBasedEncoder) {
+	e = &GenericTemplateBasedEncoder{
+		message:        message,
+		service:        nil,
+		file:           file,
+		templateDir:    templateDir,
+		debug:          debug,
+		destinationDir: destinationDir,
+		enum:           file.GetEnumType(),
+	}
+	if debug {
+		log.Printf("new encoder: file=%q message=%q template-dir=%q", file.GetName(), message.GetName(), templateDir)
+	}
+	pgghelpers.InitPathMap(file)
+
+	return
+}
+
+func NewGenericAllTemplateBasedEncoder(templateDir string, files []*descriptor.FileDescriptorProto, debug bool, destinationDir string) (e *GenericTemplateBasedEncoder) {
+	e = &GenericTemplateBasedEncoder{
+		service:        nil,
+		files:          files,
+		templateDir:    templateDir,
+		debug:          debug,
+		destinationDir: destinationDir,
+	}
+	if debug {
+		log.Printf("new encoder: all files template-dir=%q", templateDir)
+	}
+	pgghelpers.InitPathMaps(files)
 
 	return
 }
@@ -127,12 +166,14 @@ func (e *GenericTemplateBasedEncoder) genAst(templateFilename string) (*Ast, err
 		PWD:            pwd,
 		GoPWD:          goPwd,
 		File:           e.file,
+		Files:          e.files,
 		TemplateDir:    e.templateDir,
 		DestinationDir: e.destinationDir,
 		RawFilename:    templateFilename,
 		Filename:       "",
 		Service:        e.service,
 		Enum:           e.enum,
+		Message:        e.message,
 	}
 	buffer := new(bytes.Buffer)
 	tmpl, err := template.New("").Funcs(pgghelpers.ProtoHelpersFuncMap).Parse(templateFilename)


### PR DESCRIPTION
I needed to generate a file per message as well as a single file with access to all of the AST.
So I added a `type` flag that you can pass the following options:
`message`: Generate a file per message definition, allows you to create files like `{{.Message.Name}}.go.tmpl`
`service`: Generate a file per service definition. This was the previous behavior and is now the default.
`file`: Generate a file per .proto file. This allows you to generate per file templates if those proto files have multiple service definitions.
`none`: Generates a single file. This gives you access to `.Files` which is a slice of all the `.File` descriptors.