### PR TITLE
Update the znly/protoc image 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM		znly/protoc
+FROM		znly/protoc:0.3.0
 
 ENV		GOPATH=/go \
 		PATH=/go/bin:${PATH}


### PR DESCRIPTION
As you can see here: https://hub.docker.com/r/znly/protoc/tags/
latest isn't the latest image built.